### PR TITLE
New awesome image comparison using pixelmatch

### DIFF
--- a/lib/harness.js
+++ b/lib/harness.js
@@ -36,7 +36,7 @@ module.exports = function (directory, implementation, options, run) {
                 bearing: 0,
                 classes: [],
                 center: [0, 0],
-                allowed: 0.001
+                allowed: 0.0001
             }, info[test]);
 
             if ('diff' in params) {

--- a/lib/render.js
+++ b/lib/render.js
@@ -3,29 +3,25 @@
 var fs = require('fs');
 var path = require('path');
 var PNG = require('pngjs').PNG;
-var spawn = require('child_process').spawn;
 var harness = require('./harness');
+var pixelmatch = require('pixelmatch');
 
 function compare(actual, expected, diff, callback) {
-    var child = spawn('compare', ['-metric', 'MAE', actual, expected, diff]);
-    var error = '';
 
-    child.stderr.on('data', function (data) {
-        error += data.toString();
+    fs.createReadStream(actual).pipe(new PNG()).on('parsed', function () {
+        var actualImg = this;
+
+        fs.createReadStream(expected).pipe(new PNG()).on('parsed', function () {
+            var diffImg = new PNG({width: this.width, height: this.height});
+
+            var numPixels = pixelmatch(actualImg.data, this.data, diffImg.data, this.width, this.height, 0.005);
+            var difference = numPixels / (this.width * this.height);
+
+            diffImg.pack().pipe(fs.createWriteStream(diff)).on('finish', function () {
+                callback(null, difference);
+            });
+        });
     });
-
-    child.on('exit', function (code) {
-        // The compare program returns 2 on error otherwise 0 if the images are similar or 1 if they are dissimilar.
-        if (code === 2) {
-            callback(error.trim(), Infinity);
-        } else {
-            var match = error.match(/^\d+(?:\.\d+)?\s+\(([^\)]+)\)\s*$/);
-            var difference = match ? parseFloat(match[1]) : Infinity;
-            callback(match ? '' : error, difference);
-        }
-    });
-
-    child.stdin.end();
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "extend": "^3.0.0",
     "handlebars": "^4.0.1",
     "mkdirp": "^0.5.1",
+    "pixelmatch": "^1.1.0",
     "pngjs": "^0.4.0",
     "queue-async": "^1.0.7",
     "st": "^0.5.5"

--- a/render-tests/icon-opacity/info.json
+++ b/render-tests/icon-opacity/info.json
@@ -8,6 +8,10 @@
         "height": 256
     },
     "literal": {
+        "ignored": {
+            "js": "https://github.com/mapbox/mapbox-gl-js/issues/1569",
+            "native": "https://github.com/mapbox/mapbox-gl-native/issues/1542"
+        },
         "zoom": 14,
         "center": [52.499167, 13.418056],
         "height": 256,

--- a/render-tests/text-halo-blur/info.json
+++ b/render-tests/text-halo-blur/info.json
@@ -1,16 +1,28 @@
 {
     "default": {
+        "ignored": {
+            "js": "",
+            "native": ""
+        },
         "zoom": 14,
         "center": [52.499167, 13.418056],
         "height": 256
     },
     "literal": {
+        "ignored": {
+            "js": "",
+            "native": ""
+        },
         "zoom": 14,
         "center": [52.499167, 13.418056],
         "height": 256,
         "classes": ["literal"]
     },
     "function": {
+        "ignored": {
+            "js": "",
+            "native": ""
+        },
         "zoom": 14,
         "center": [52.499167, 13.418056],
         "height": 256,

--- a/render-tests/text-halo-width/info.json
+++ b/render-tests/text-halo-width/info.json
@@ -5,6 +5,10 @@
         "height": 256
     },
     "literal": {
+        "ignored": {
+            "js": "",
+            "native": ""
+        },
         "zoom": 14,
         "center": [52.499167, 13.418056],
         "height": 256,


### PR DESCRIPTION
Makes the test suite many times more awesome and useful by ditching ImageMagick in favor of my new [pixelmatch](https://github.com/mapbox/pixelmatch) library. Closes #24. 

Take a look at the [example output](https://circle-artifacts.com/gh/mapbox/mapbox-gl-js/1193/artifacts/0/home/ubuntu/mapbox-gl-js/node_modules/mapbox-gl-test-suite/render-tests/index.html) and compare that with the [current one](https://circle-artifacts.com/gh/mapbox/mapbox-gl-js/1182/artifacts/0/home/ubuntu/mapbox-gl-js/node_modules/mapbox-gl-test-suite/render-tests/index.html).

- [ ] possibly update outdated reference images @jfirebaugh 
- [ ] update ignored tests for JS & Native @jfirebaugh 

cc @mapbox/gl