### PR TITLE
Specify raster-fade-duration in video test

### DIFF
--- a/render-tests/video/default/style.json
+++ b/render-tests/video/default/style.json
@@ -47,7 +47,9 @@
       "id": "video",
       "type": "raster",
       "source": "video",
-      "paint": {}
+      "paint": {
+        "raster-fade-duration": 0
+      }
     }
   ]
 }


### PR DESCRIPTION
The changes in [mapbox/mapbox-gl-js#826ac59d55984d21e22e9f93d18989a05d4fc5a5](https://github.com/mapbox/mapbox-gl-js/pull/2667/commits/826ac59d55984d21e22e9f93d18989a05d4fc5a5) (part of https://github.com/mapbox/mapbox-gl-js/pull/2667 )  result in the `raster-fade-duration` property now working for layers targeting `video` and `image` sources, as opposed to just `raster` sources.  So, it is now necessary to explicitly set the value to 0, overriding the default of 300ms.