### PR TITLE
Add properties value to achieve valid geojson

### DIFF
--- a/render-tests/sprites/1x-screen-1x-icon/style.json
+++ b/render-tests/sprites/1x-screen-1x-icon/style.json
@@ -17,6 +17,7 @@
       "type": "geojson",
       "data": {
         "type": "Feature",
+        "properties": {},
         "geometry": {
           "type": "Point",
           "coordinates": [

--- a/render-tests/sprites/1x-screen-2x-icon/style.json
+++ b/render-tests/sprites/1x-screen-2x-icon/style.json
@@ -17,6 +17,7 @@
       "type": "geojson",
       "data": {
         "type": "Feature",
+        "properties": {},
         "geometry": {
           "type": "Point",
           "coordinates": [

--- a/render-tests/sprites/2x-screen-1x-icon/style.json
+++ b/render-tests/sprites/2x-screen-1x-icon/style.json
@@ -17,6 +17,7 @@
       "type": "geojson",
       "data": {
         "type": "Feature",
+        "properties": {},
         "geometry": {
           "type": "Point",
           "coordinates": [

--- a/render-tests/sprites/2x-screen-2x-icon/style.json
+++ b/render-tests/sprites/2x-screen-2x-icon/style.json
@@ -17,6 +17,7 @@
       "type": "geojson",
       "data": {
         "type": "Feature",
+        "properties": {},
         "geometry": {
           "type": "Point",
           "coordinates": [


### PR DESCRIPTION
Our native geojson parser now expects a `properties` key on features, conforming to the geojson spec.

Refs https://github.com/mapbox/mapbox-gl-native/pull/5514.