### PR TITLE
Revert "Ignore tests that frequently segfault in GL JS"

### DIFF
--- a/render-tests/text-offset/literal-multiline-anchorright-justifycenter-offsetnegative/style.json
+++ b/render-tests/text-offset/literal-multiline-anchorright-justifycenter-offsetnegative/style.json
@@ -2,11 +2,7 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256,
-      "ignored": {
-        "js": "https://github.com/mapbox/mapbox-gl-js/issues/2860"
-      },
-      "js": false
+      "height": 256
     }
   },
   "center": [

--- a/render-tests/text-offset/literal-multiline-anchorright-justifycenter-offsetpositive/style.json
+++ b/render-tests/text-offset/literal-multiline-anchorright-justifycenter-offsetpositive/style.json
@@ -2,11 +2,7 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256,
-      "ignored": {
-        "js": "https://github.com/mapbox/mapbox-gl-js/issues/2860"
-      },
-      "js": false
+      "height": 256
     }
   },
   "center": [


### PR DESCRIPTION
This reverts commit 9007694833172b364acb9a6a56113241dc9f07ac.

ref https://github.com/mapbox/mapbox-gl-js/pull/2968