### PR TITLE
[native circle-radius/antimeridian

### DIFF
--- a/render-tests/circle-radius/antimeridian/style.json
+++ b/render-tests/circle-radius/antimeridian/style.json
@@ -3,10 +3,7 @@
   "metadata": {
     "test": {
       "width": 512,
-      "height": 512,
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/5600"
-      }
+      "height": 512
     }
   },
   "center": [

--- a/render-tests/line-color/property-function/style.json
+++ b/render-tests/line-color/property-function/style.json
@@ -2,7 +2,10 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256
+      "height": 256,
+      "ignored": {
+        "native": "https://github.com/mapbox/mapbox-gl-native/issues/6090"
+      }
     }
   },
   "center": [


### PR DESCRIPTION
Also bypass 'line-color/property-function' in native - https://github.com/mapbox/mapbox-gl-native/issues/6090