### PR TITLE
Better test name matching mechanism

### DIFF
--- a/lib/harness.js
+++ b/lib/harness.js
@@ -19,7 +19,8 @@ module.exports = function (directory, implementation, options, run) {
         var id = group + '/' + test;
 
         for (var i = 0; i < tests.length; i++) {
-            if (id.indexOf(tests[i]) >= 0)
+            var k = id.indexOf(tests[i]);
+            if (k === 0 || id[k - 1] === '-' || id[k - 1] === '/')
                 return true;
         }
 

--- a/lib/harness.js
+++ b/lib/harness.js
@@ -10,16 +10,16 @@ module.exports = function (directory, implementation, options, run) {
     var q = queue(1);
     var server = require('./server')();
 
-    var tests = (options.tests || []).map(function (t) {
-        return t.split('/');
-    });
+    var tests = options.tests || [];
 
     function shouldRunTest(group, test) {
         if (tests.length === 0)
             return true;
 
+        var id = group + '/' + test;
+
         for (var i = 0; i < tests.length; i++) {
-            if (tests[i][0] === group && (tests[i].length === 1 || tests[i][1] === test))
+            if (id.indexOf(tests[i]) >= 0)
                 return true;
         }
 


### PR DESCRIPTION
I got tired of remembering exact names of test groups and their subtests, and not being able to, for example, simply run all line-related tests at once (or related to any other feature I'm working on).

This PR changes the matching logic so that you can just write `node test/render.test.js line` and it will run `line-color`, `line-blur`, `line-cap`, etc. It only matches the beginning of keywords, so `line` won't match `outline`, but will match `1024-line` for example.

It will match both groups and subtests, so you can do `property-function` to run all DDS-related tests. You can still do `line-color/default` to match specific tests, or `line-color/` to match a specific group.

cc @jfirebaugh @lucaswoj