### PR TITLE
Move out mapnik dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "devDependencies": {
     "jsonlint": "^1.6.2",
     "mapbox-gl-style-spec": "8.5.0",
-    "mapnik": "^3.5.13",
     "sponge": "^0.1.0"
   },
   "scripts": {

--- a/tiles/package.json
+++ b/tiles/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "mapnik": "^3.5.13"
+  }
+}


### PR DESCRIPTION
`mapnik` is a very heavy dependency that always takes a TON of time to install for me, but it's only needed when upgrading tile fixtures when MVT encoding changes, which is a rare and purely manual process. So I suggest moving it out to the `tiles` folder so that test-suite installation is fast and lightweight for all GL JS devs. 

👀 @lucaswoj @jfirebaugh 