### PR TITLE
Native osmesa

### DIFF
--- a/query-tests/regressions/mapbox-gl-js#3534/style.json
+++ b/query-tests/regressions/mapbox-gl-js#3534/style.json
@@ -2,6 +2,9 @@
   "version": 8,
   "metadata": {
     "test": {
+      "ignored": {
+        "native": "https://github.com/mapbox/mapbox-gl-native/issues/6670"
+      },
       "collisionDebug": true,
       "width": 500,
       "height": 500,

--- a/render-tests/fill-outline-color/function/style.json
+++ b/render-tests/fill-outline-color/function/style.json
@@ -3,10 +3,7 @@
   "metadata": {
     "test": {
       "width": 64,
-      "height": 64,
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1555"
-      }
+      "height": 64
     }
   },
   "sources": {

--- a/render-tests/fill-outline-color/literal/style.json
+++ b/render-tests/fill-outline-color/literal/style.json
@@ -3,10 +3,7 @@
   "metadata": {
     "test": {
       "width": 64,
-      "height": 64,
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1555"
-      }
+      "height": 64
     }
   },
   "sources": {

--- a/render-tests/fill-outline-color/multiply/style.json
+++ b/render-tests/fill-outline-color/multiply/style.json
@@ -3,10 +3,7 @@
   "metadata": {
     "test": {
       "width": 64,
-      "height": 64,
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1555"
-      }
+      "height": 64
     }
   },
   "sources": {

--- a/render-tests/fill-outline-color/opacity/style.json
+++ b/render-tests/fill-outline-color/opacity/style.json
@@ -3,10 +3,7 @@
   "metadata": {
     "test": {
       "width": 64,
-      "height": 64,
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1555"
-      }
+      "height": 64
     }
   },
   "sources": {

--- a/render-tests/fill-outline-color/property-function/style.json
+++ b/render-tests/fill-outline-color/property-function/style.json
@@ -5,7 +5,7 @@
       "width": 64,
       "height": 64,
       "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1555 https://github.com/mapbox/mapbox-gl-native/issues/4860"
+        "native": "https://github.com/mapbox/mapbox-gl-native/issues/4860"
       }
     }
   },

--- a/render-tests/fill-outline-color/zoom-and-property-function/style.json
+++ b/render-tests/fill-outline-color/zoom-and-property-function/style.json
@@ -5,7 +5,7 @@
       "width": 64,
       "height": 64,
       "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1555 https://github.com/mapbox/mapbox-gl-native/issues/4860"
+        "native": "https://github.com/mapbox/mapbox-gl-native/issues/4860"
       }
     }
   },

--- a/render-tests/icon-offset/literal/style.json
+++ b/render-tests/icon-offset/literal/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      },
       "height": 256
     }
   },

--- a/render-tests/icon-opacity/default/style.json
+++ b/render-tests/icon-opacity/default/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      },
       "height": 256
     }
   },

--- a/render-tests/icon-opacity/function/style.json
+++ b/render-tests/icon-opacity/function/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      },
       "height": 256
     }
   },

--- a/render-tests/icon-opacity/icon-only/style.json
+++ b/render-tests/icon-opacity/icon-only/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      },
       "height": 256
     }
   },

--- a/render-tests/icon-opacity/literal/style.json
+++ b/render-tests/icon-opacity/literal/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      },
       "height": 256
     }
   },

--- a/render-tests/icon-opacity/text-and-icon/style.json
+++ b/render-tests/icon-opacity/text-and-icon/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      },
       "height": 256
     }
   },

--- a/render-tests/icon-size/default/style.json
+++ b/render-tests/icon-size/default/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      },
       "height": 256
     }
   },

--- a/render-tests/icon-translate-anchor/map/style.json
+++ b/render-tests/icon-translate-anchor/map/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      },
       "height": 256
     }
   },

--- a/render-tests/icon-translate-anchor/viewport/style.json
+++ b/render-tests/icon-translate-anchor/viewport/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      },
       "height": 256
     }
   },

--- a/render-tests/icon-translate/default/style.json
+++ b/render-tests/icon-translate/default/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      },
       "height": 256
     }
   },

--- a/render-tests/icon-translate/function/style.json
+++ b/render-tests/icon-translate/function/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      },
       "height": 256
     }
   },

--- a/render-tests/icon-translate/literal/style.json
+++ b/render-tests/icon-translate/literal/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      },
       "height": 256
     }
   },

--- a/render-tests/icon-visibility/visible/style.json
+++ b/render-tests/icon-visibility/visible/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      },
       "height": 256
     }
   },

--- a/render-tests/line-dasharray/functional-line-width/style.json
+++ b/render-tests/line-dasharray/functional-line-width/style.json
@@ -2,10 +2,7 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256,
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1555"
-      }
+      "height": 256
     }
   },
   "center": [

--- a/render-tests/raster-brightness/default/style.json
+++ b/render-tests/raster-brightness/default/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1600"
-      },
       "height": 256
     }
   },

--- a/render-tests/raster-brightness/literal/style.json
+++ b/render-tests/raster-brightness/literal/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1600"
-      },
       "height": 256
     }
   },

--- a/render-tests/raster-contrast/default/style.json
+++ b/render-tests/raster-contrast/default/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1600"
-      },
       "height": 256
     }
   },

--- a/render-tests/raster-contrast/function/style.json
+++ b/render-tests/raster-contrast/function/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1600"
-      },
       "height": 256
     }
   },

--- a/render-tests/raster-contrast/literal/style.json
+++ b/render-tests/raster-contrast/literal/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1600"
-      },
       "height": 256
     }
   },

--- a/render-tests/raster-hue-rotate/default/style.json
+++ b/render-tests/raster-hue-rotate/default/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1600"
-      },
       "height": 256
     }
   },

--- a/render-tests/raster-hue-rotate/function/style.json
+++ b/render-tests/raster-hue-rotate/function/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1600"
-      },
       "height": 256
     }
   },

--- a/render-tests/raster-hue-rotate/literal/style.json
+++ b/render-tests/raster-hue-rotate/literal/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1600"
-      },
       "height": 256
     }
   },

--- a/render-tests/raster-opacity/default/style.json
+++ b/render-tests/raster-opacity/default/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "?"
-      },
       "height": 256
     }
   },

--- a/render-tests/raster-opacity/function/style.json
+++ b/render-tests/raster-opacity/function/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "?"
-      },
       "height": 256
     }
   },

--- a/render-tests/raster-opacity/literal/style.json
+++ b/render-tests/raster-opacity/literal/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "?"
-      },
       "height": 256
     }
   },

--- a/render-tests/raster-saturation/default/style.json
+++ b/render-tests/raster-saturation/default/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1600"
-      },
       "height": 256
     }
   },

--- a/render-tests/raster-saturation/function/style.json
+++ b/render-tests/raster-saturation/function/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1600"
-      },
       "height": 256
     }
   },

--- a/render-tests/raster-saturation/literal/style.json
+++ b/render-tests/raster-saturation/literal/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1600"
-      },
       "height": 256
     }
   },

--- a/render-tests/raster-visibility/visible/style.json
+++ b/render-tests/raster-visibility/visible/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1600"
-      },
       "height": 256
     }
   },

--- a/render-tests/regressions/mapbox-gl-js#2305/style.json
+++ b/render-tests/regressions/mapbox-gl-js#2305/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1555"
-      }
     }
   },
   "zoom": 2,

--- a/render-tests/regressions/mapbox-gl-js#2477/style.json
+++ b/render-tests/regressions/mapbox-gl-js#2477/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1555"
-      },
       "operations": [
         ["addClass", "mapbox", {"transition": false}],
         ["setPaintProperty", "land", "fill-pattern", "zoo_icon"],

--- a/render-tests/regressions/mapbox-gl-js#2533/style.json
+++ b/render-tests/regressions/mapbox-gl-js#2533/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/1555"
-      },
       "operations": [
         ["setPaintProperty", "land", "fill-pattern", "zoo_icon"],
         ["wait"]

--- a/render-tests/symbol-placement/point/style.json
+++ b/render-tests/symbol-placement/point/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      },
       "height": 256
     }
   },

--- a/render-tests/symbol-spacing/point-close/style.json
+++ b/render-tests/symbol-spacing/point-close/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      },
       "height": 256
     }
   },

--- a/render-tests/symbol-spacing/point-far/style.json
+++ b/render-tests/symbol-spacing/point-far/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      },
       "height": 256
     }
   },

--- a/render-tests/symbol-visibility/visible/style.json
+++ b/render-tests/symbol-visibility/visible/style.json
@@ -2,9 +2,6 @@
   "version": 8,
   "metadata": {
     "test": {
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      },
       "height": 256
     }
   },

--- a/render-tests/text-font/chinese/style.json
+++ b/render-tests/text-font/chinese/style.json
@@ -4,10 +4,7 @@
     "test": {
       "width": 512,
       "height": 512,
-      "allowed": 0.0003,
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/3175"
-      }
+      "allowed": 0.0003
     }
   },
   "center": [

--- a/render-tests/text-max-width/ideographic-breaking/style.json
+++ b/render-tests/text-max-width/ideographic-breaking/style.json
@@ -2,7 +2,10 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 512
+      "height": 512,
+      "ignored": {
+          "native": "https://github.com/mapbox/mapbox-gl-native/issues/1223"
+      }
     }
   },
   "sources": {

--- a/render-tests/zoomed-fill/default/style.json
+++ b/render-tests/zoomed-fill/default/style.json
@@ -2,10 +2,7 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256,
-      "ignored": {
-        "native": "https://github.com/mapbox/mapbox-gl-native/issues/4593"
-      }
+      "height": 256
     }
   },
   "center": [


### PR DESCRIPTION
Unignores 42 render tests with the switch to OSMesa (Gallium+LLVMpipe) on Travis CI for -native.