### PR TITLE
Don't add style properties to params

### DIFF
--- a/lib/harness.js
+++ b/lib/harness.js
@@ -54,11 +54,6 @@ module.exports = function (directory, implementation, options, run) {
                 allowed: 0.00015
             }, style.metadata && style.metadata.test);
 
-            params.center = style.center;
-            params.zoom = style.zoom;
-            params.bearing = style.bearing;
-            params.pitch = style.pitch;
-
             if (params[implementation] === false) {
                 console.log(colors.gray('* skipped ' + params.group + ' ' + params.test));
                 return;


### PR DESCRIPTION
gl-js/gl-native can read these values from the style just fine.

This is part of the fix to get #161 failing (so we know it's a good regression test).

I've tested both gl-js and gl-native with this change; both are green.