### PR TITLE
Revert "Add ignores for not-yet-merged GL JS PR"

### DIFF
--- a/render-tests/line-blur/property-function/style.json
+++ b/render-tests/line-blur/property-function/style.json
@@ -4,7 +4,6 @@
     "test": {
       "height": 256,
       "ignored":{
-        "js": "https://github.com/mapbox/mapbox-gl-js/pull/3033",
         "native": "https://github.com/mapbox/mapbox-gl-native/issues/4860"
       }
     }

--- a/render-tests/line-gap-width/property-function/style.json
+++ b/render-tests/line-gap-width/property-function/style.json
@@ -4,7 +4,6 @@
     "test": {
       "height": 256,
       "ignored":{
-        "js": "https://github.com/mapbox/mapbox-gl-js/pull/3033",
         "native": "https://github.com/mapbox/mapbox-gl-native/issues/4860"
       }
     }

--- a/render-tests/line-offset/property-function/style.json
+++ b/render-tests/line-offset/property-function/style.json
@@ -4,7 +4,6 @@
     "test": {
       "height": 256,
       "ignored":{
-        "js": "https://github.com/mapbox/mapbox-gl-js/pull/3033",
         "native": "https://github.com/mapbox/mapbox-gl-native/issues/4860"
       }
     }

--- a/render-tests/line-opacity/property-function/style.json
+++ b/render-tests/line-opacity/property-function/style.json
@@ -4,7 +4,6 @@
     "test": {
       "height": 256,
       "ignored":{
-        "js": "https://github.com/mapbox/mapbox-gl-js/pull/3033",
         "native": "https://github.com/mapbox/mapbox-gl-native/issues/4860"
       }
     }

--- a/render-tests/line-width/property-function/style.json
+++ b/render-tests/line-width/property-function/style.json
@@ -4,7 +4,6 @@
     "test": {
       "height": 256,
       "ignored":{
-        "js": "https://github.com/mapbox/mapbox-gl-js/pull/3033",
         "native": "https://github.com/mapbox/mapbox-gl-native/issues/4860"
       }
     }


### PR DESCRIPTION
This reverts commit 3c678a3ebc2c87f58e9e1d2eaff344413b53a5be.

To be merged in immediately before https://github.com/mapbox/mapbox-gl-js/pull/3033