### PR TITLE
Ignore circle-stroke-* tests in GL native

### DIFF
--- a/render-tests/circle-blur/literal-stroke/style.json
+++ b/render-tests/circle-blur/literal-stroke/style.json
@@ -2,7 +2,10 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256
+      "height": 256,
+      "ignored": {
+        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7231"
+      }
     }
   },
   "center": [

--- a/render-tests/circle-stroke-color/default/style.json
+++ b/render-tests/circle-stroke-color/default/style.json
@@ -2,7 +2,10 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256
+      "height": 256,
+      "ignored": {
+        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7231"
+      }
     }
   },
   "center": [

--- a/render-tests/circle-stroke-color/function/style.json
+++ b/render-tests/circle-stroke-color/function/style.json
@@ -2,7 +2,10 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256
+      "height": 256,
+      "ignored": {
+        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7231"
+      }
     }
   },
   "center": [

--- a/render-tests/circle-stroke-color/literal/style.json
+++ b/render-tests/circle-stroke-color/literal/style.json
@@ -2,7 +2,10 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256
+      "height": 256,
+      "ignored": {
+        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7231"
+      }
     }
   },
   "center": [

--- a/render-tests/circle-stroke-opacity/default/style.json
+++ b/render-tests/circle-stroke-opacity/default/style.json
@@ -2,7 +2,10 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256
+      "height": 256,
+      "ignored": {
+        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7231"
+      }
     }
   },
   "center": [

--- a/render-tests/circle-stroke-opacity/function/style.json
+++ b/render-tests/circle-stroke-opacity/function/style.json
@@ -2,7 +2,10 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256
+      "height": 256,
+      "ignored": {
+        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7231"
+      }
     }
   },
   "center": [

--- a/render-tests/circle-stroke-opacity/literal/style.json
+++ b/render-tests/circle-stroke-opacity/literal/style.json
@@ -2,7 +2,10 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256
+      "height": 256,
+      "ignored": {
+        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7231"
+      }
     }
   },
   "center": [

--- a/render-tests/circle-stroke-width/antimeridian/style.json
+++ b/render-tests/circle-stroke-width/antimeridian/style.json
@@ -3,7 +3,10 @@
   "metadata": {
     "test": {
       "width": 512,
-      "height": 512
+      "height": 512,
+      "ignored": {
+        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7231"
+      }
     }
   },
   "center": [

--- a/render-tests/circle-stroke-width/default/style.json
+++ b/render-tests/circle-stroke-width/default/style.json
@@ -2,7 +2,10 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256
+      "height": 256,
+      "ignored": {
+        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7231"
+      }
     }
   },
   "center": [

--- a/render-tests/circle-stroke-width/function/style.json
+++ b/render-tests/circle-stroke-width/function/style.json
@@ -2,7 +2,10 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256
+      "height": 256,
+      "ignored": {
+        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7231"
+      }
     }
   },
   "center": [

--- a/render-tests/circle-stroke-width/literal/style.json
+++ b/render-tests/circle-stroke-width/literal/style.json
@@ -2,7 +2,10 @@
   "version": 8,
   "metadata": {
     "test": {
-      "height": 256
+      "height": 256,
+      "ignored": {
+        "native": "https://github.com/mapbox/mapbox-gl-native/issues/7231"
+      }
     }
   },
   "center": [


### PR DESCRIPTION
cc @jfirebaugh 
ref https://github.com/mapbox/mapbox-gl-native/issues/7231

Blocked on https://github.com/mapbox/mapbox-gl-js/pull/3716 to test this on GL JS